### PR TITLE
Explicit string comparison since bools often don't behave like bools.

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -16,7 +16,7 @@ def scm_checkout(skip_disable=false) {
     node("on-master") {
         stage("Setup") {
             checkout(scm)
-            if (!skip_disable) {
+            if (skip_disable == 'true') {
                 // Obtain the last commit message and examine it for skip directives.
                 logoutput = sh(script:"git log -1 --pretty=%B", returnStdout: true).trim()
                 if (logoutput.contains("[ci skip]") || logoutput.contains("[skip ci]")) {


### PR DESCRIPTION
The comparison for selecting whether or not the `[skip ci]` functionality is exercised was noticed to not work in the JWST regression test build. It looks like there are some cases where a `bool` is better treated like a string for the purposes of comparison.