### PR TITLE
Post-process test report file to prepend build config name to test names

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -259,6 +259,11 @@ def processTestReport(config, index) {
         "skippedUnstableThresh: ${config.skippedUnstableThresh}\n" +
         "skippedFailureThresh: ${config.skippedFailureThresh}"
     println(thresh_summary)
+
+    // Process the XML results file to include the build config name as a prefix
+    // on each test name to make it more obvious from where each result originates.
+    sh(script:"sed -i 's/ name=\"/ name=\"${config.name} /g' *.xml")
+
     if (report_exists == 0) {
         step([$class: 'XUnitBuilder',
             thresholds: [

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -262,7 +262,7 @@ def processTestReport(config, index) {
 
     // Process the XML results file to include the build config name as a prefix
     // on each test name to make it more obvious from where each result originates.
-    sh(script:"sed -i 's/ name=\"/ name=\"${config.name} /g' *.xml")
+    sh(script:"sed -i 's/ name=\"/ name=\"[${config.name}] /g' *.xml")
 
     if (report_exists == 0) {
         step([$class: 'XUnitBuilder',


### PR DESCRIPTION
Enclose the build config name defined in the Jenkinsfile in square braces to improve readability.