### PR TITLE
Actually override the conda version when requested.

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -139,7 +139,7 @@ def installConda(version, install_dir) {
     }
 
     def cwd = pwd()
-    def conda_install_dir = "${cwd}/${install_dir}"
+    def conda_exe = "${install_dir}/bin/conda"
     def conda_installer = "Miniconda3-${installer_ver}-${OSname}-x86_64.sh"
     dl_cmd = dl_cmd + " ${conda_base_url}/${conda_installer}"
     if (!fileExists("./${conda_installer}")) {
@@ -148,6 +148,14 @@ def installConda(version, install_dir) {
 
     // Install miniconda
     sh "bash ./${conda_installer} -b -p ${install_dir}"
+
+    // Override conda version if specified and different from default.
+    def curr_ver = sh(script:"${conda_exe} --version", returnStdout: true)
+    curr_ver = curr_ver.tokenize()[1].trim()
+    if (curr_ver != version) {
+        sh "${conda_exe} install conda=${version}"
+    }
+
     return true
 }
 


### PR DESCRIPTION
Fixes bug where the `conda_ver` property of build configurations was ignored.