### PR TITLE
XML Ingestion Fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ bc0.env_vars = ['VAR_ONE=1',
                'VAR_TWO=2']
 bc0.conda_ver = '4.6.4'
 bc0.conda_packages = ['python=3.6',
-                     'pytest=3.8.2']
+                     'pytest']
 bc0.build_cmds = ["date",
                   "./access_env_var.sh",
                   "which python",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ bc0.build_cmds = ["date",
                   "./access_env_var.sh",
                   "which python",
                   "conda install ipython"]
-bc0.test_cmds = ["${PYTEST} test_75pass.py"]
+bc0.test_cmds = ["${PYTEST} tests/test_75pass.py"]
 bc0.test_configs = [data_config]
 
 
@@ -47,7 +47,7 @@ bc1 = utils.copy(bc0)
 bc1.name = 'Second'
 bc1.env_vars = ['VAR_THREE=3',
                'VAR_FOUR=4']
-bc1.test_cmds[1] = "${PYTEST} test_25pass.py"
+bc1.test_cmds[1] = "${PYTEST} tests/test_25pass.py"
 
 
 bc2 = utils.copy(bc0)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+@Library('utils@test-xml-validate') _
 
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,3 @@
-@Library('utils@test-xml-validate') _
 
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return

--- a/invalid_report.xml
+++ b/invalid_report.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<invalid>
+</invalid>
+<testsuite errors="0" failures="0" invalid-param="" name="pytest" skipped="0" tests="5" time="0.042">
+  <testcase classname="tests.test_invalid" name="test_1" time="0.001"></testcase>
+  <testcase classname="tests.test_invalid" name="test_2" time="0.001">
+    <invalid-tag>
+    </invalid-tag>
+  </testcase>
+  <testcase invalid-testcase="" classname="tests.test_invalid" name="test_3" time="0.001"></testcase>
+  <testcase classname="tests.test_invalid" name="test_4" time="0.001"></testcase>
+  <testcase classname="tests.test_invalid" name="test_5" time="0.001"></testcase>
+</testsuite>

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -8,19 +8,6 @@ import org.apache.commons.io.FilenameUtils
 import org.kohsuke.github.GitHub
 
 
-import java.util.Properties;
-
-import org.xml.sax.SAXException;
-
-import javax.xml.XMLConstants;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-import javax.xml.validation.Validator;
-
-
 @NonCPS
 // Post an issue to a particular Github repository.
 //
@@ -318,36 +305,6 @@ def publishCondaEnv(jobconfig, test_info) {
             pushToArtifactory("conda_env_dump_*", pub_repo)
         }
     }
-}
-
-
-// Validates an XML file against xunit schema
-// Returns true if valid, false otherwise.
-// Validates against Junit10 schema.
-//
-// @param xmlFilePath     string path of xml file
-def validateXML(xmlFilePath) {
-  URL schemaFile = new URL("https://github.com/jenkinsci/xunit-plugin/raw/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd");
-
-  // create a Source for the xml document to be validated
-  Source xmlFile = new StreamSource(new File(xmlFilePath));
-
-  // Create a SchemaFactory capable of understanding WXS schemas
-  SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-  Schema schema = factory.newSchema(schemaFile);
-
-  // Create a Validator instance, which can be used to validate an instance document
-  Validator validator = schema.newValidator();
-
-  // Validate the xml document
-  try {
-      validator.validate(xmlFile);
-  } catch (SAXException e) {
-      println(e)
-      // instance document is invalid!
-      return false;
-  }
-  return true;
 }
 
 


### PR DESCRIPTION
Updated test processing to find all xml files in the root and attempt to ingest them all. If a xml file is not a valid junit schema, jenkins will skip ingesting this file. This would allow xml reports generated from coverage tools, etc. to be essentially ignored while picking up any valid junit reports.

Fixes: #45 

Should also fix the observed issue of multiple xml files in the root causing the shell command to return a non-zero status resulting in jenkins skipping ingestion of any junit reports.

Should also address: [JWQL Issue #364](https://github.com/spacetelescope/jwql/issues/364) pending the failure threshold for tests is set correctly in the job config as the test reports will be ingested with this fix.