### PR TITLE
Dump YAML version of conda environment

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -525,8 +525,6 @@ def buildAndTest(config) {
             extra_yml_1 = "    - ${remote_repo}@${commit}"
             sh "echo '${extra_yml_1}' >> ${dump_name}"
 
-            sh "more ${dump_name}"
-
             // Stash spec file for use on master node.
             stash includes: '**/conda_env_dump*',
                   name: "conda_env_dump_${config.name}",

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -510,8 +510,6 @@ def buildAndTest(config) {
             sh(script: "${conda_exe} env export > '${dump_name}'")
             remote_out = sh(script: "git remote -v | head -1", returnStdout: true).trim()
             remote_repo = remote_out.tokenize()[1]
-	    //commit = sh(script: "git rev-parse head", returnStdout: true).trim()
-	    //commit = sh(script: "git show --oneline", returnStdout: true).trim().tokenize()[0]
             commit = sh(script: "git rev-parse HEAD", returnStdout: true).trim()
             // Remove 'prefix' line as it isn't needed and complicates the
             // addition of the 'pip' section.

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -511,7 +511,8 @@ def buildAndTest(config) {
             remote_out = sh(script: "git remote -v | head -1", returnStdout: true).trim()
             remote_repo = remote_out.tokenize()[1]
 	    //commit = sh(script: "git rev-parse head", returnStdout: true).trim()
-	    commit = sh(script: "git show --oneline", returnStdout: true).trim().tokenize()[0]
+	    //commit = sh(script: "git show --oneline", returnStdout: true).trim().tokenize()[0]
+            commit = sh(script: "git rev-parse HEAD", returnStdout: true).trim()
             // Remove 'prefix' line as it isn't needed and complicates the
             // addition of the 'pip' section.
             sh(script: "sed -i '/prefix/d' ${dump_name}")

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -525,6 +525,8 @@ def buildAndTest(config) {
             extra_yml_1 = "    - ${remote_repo}@${commit}"
             sh "echo '${extra_yml_1}' >> ${dump_name}"
 
+            sh "more ${dump_name}"
+
             // Stash spec file for use on master node.
             stash includes: '**/conda_env_dump*',
                   name: "conda_env_dump_${config.name}",


### PR DESCRIPTION
To pave the way toward a reduced dependence upon conda, dump a YAML version of the environment spec via `conda env export`, which includes pip-installed packages and a pip-like entry for the project being built/tested as well which is meant to allow recreation of a hybrid conda/non-conda environment at a later time.
