### PR TITLE
Use `dotglob` with mv command to get all files, including hidden

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-//@Library('utils@clonedir') _
+//@Library('utils@subdir') _
 
 
 // [skip ci] and [ci skip] have no effect here.


### PR DESCRIPTION
Add dir() block in publishCondaEnv to allow access to `setup.cfg` file for property extraction.