### PR TITLE
Override value of HOME to be the job's workspace root dir.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,8 @@ bc0.env_vars = ['VAR_ONE=1',
 bc0.conda_ver = '4.6.4'
 bc0.conda_packages = ['python=3.6',
                      'pytest']
-bc0.build_cmds = ["date",
-                  "env",
+bc0.build_cmds = ["env",
+                  "ls -al,
                   "conda config --show",
                   "./access_env_var.sh",
                   "which python",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-//@Library('utils@homedir') _
+@Library('utils@homedir') _
 
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return
@@ -36,6 +36,8 @@ bc0.conda_ver = '4.6.4'
 bc0.conda_packages = ['python=3.6',
                      'pytest']
 bc0.build_cmds = ["date",
+                  "env",
+                  "conda config --show",
                   "./access_env_var.sh",
                   "which python",
                   "conda install ipython"]
@@ -53,7 +55,8 @@ bc1.test_cmds[1] = "${PYTEST} tests/test_25pass.py"
 bc2 = utils.copy(bc0)
 bc2.name = 'Third build config'
 bc2.conda_packages = ['python=3.6']
-bc2.build_cmds = ["which python"]
+bc2.build_cmds = ["env",
+                  "which python"]
 bc2.test_cmds = ["ls -al"]
 bc2.test_configs = []
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,8 @@ bc0.conda_ver = '4.6.4'
 bc0.conda_packages = ['python=3.6',
                      'pytest']
 bc0.build_cmds = ["env",
-                  "ls -al",
+                  "ls -al ..", // Workspace root.
+                  "ls -al",    // Project clone dir.
                   "conda config --show",
                   "./access_env_var.sh",
                   "which python",
@@ -57,7 +58,8 @@ bc2.name = 'Third build config'
 bc2.conda_packages = ['python=3.6']
 bc2.build_cmds = ["env",
                   "which python"]
-bc2.test_cmds = ["ls -al"]
+bc2.test_cmds = ["ls -al ..", // Workspace root.
+                 "ls -al"]    // Project clone dir.
 bc2.test_configs = []
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('utils@homedir') _
+//@Library('utils@homedir') _
 
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-//@Library('utils@ymlfix') _
+//@Library('utils@homedir') _
 
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ bc0.conda_ver = '4.6.4'
 bc0.conda_packages = ['python=3.6',
                      'pytest']
 bc0.build_cmds = ["env",
-                  "ls -al,
+                  "ls -al",
                   "conda config --show",
                   "./access_env_var.sh",
                   "which python",

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -622,6 +622,10 @@ def expandEnvVars(config) {
     // Expand environment variable specifications by using the shell
     // to dereference any var references and then render the entire
     // value as a canonical path.
+    
+    // Override the HOME dir to be the job workspace.
+    config.env_vars.add("HOME=${env.WORKSPACE}")
+
     for (var in config.env_vars) {
         // Process each var in an environment defined by all the prior vars.
         withEnv(config.runtime) {


### PR DESCRIPTION
This corrects a problem wherein jobs that cause files to be stored in `$HOME`, like conda, when its configuration is modified, would store them in a directory common to all jobs on a given node.

Example: Conda had stored a config file in a common HOME dir defined by the Jenkins node configuration, and certain undesired config values, i.e. channel URLs were being inherited silently by later jobs.

This PR sets the value of each `BuildConfig`'s `$HOME` to be the root of its respective workspace.