### PR TITLE
Use appropriate location of standard tools when on macos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-//@Library('utils@master') _
+//@Library('utils@sedtest') _
 
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -122,6 +122,7 @@ def installConda(version, install_dir) {
     if (uname == "Darwin") {
         OSname = "MacOSX"
         println("OSname=${OSname}")
+        env.PATH = "/sw/bin:$PATH"
     }
     if (uname == "Linux") {
         OSname = uname
@@ -341,7 +342,7 @@ def processTestReport(config) {
             command = "cp '${repfile}' '${repfile}.modified'"
             sh(script:command)
         }
-        sh(script:"sed -i 's/ name=\"/ name=\"[${config.name}] /g' *.xml.modified")
+        sh(script: "sed -i 's/ name=\"/ name=\"[${config.name}] /g' *.xml.modified")
         step([$class: 'XUnitBuilder',
             thresholds: [
             [$class: 'SkippedThreshold', unstableThreshold: "${config.skippedUnstableThresh}"],


### PR DESCRIPTION
Useful (GNU) versions of standard tools, like sed, are kept in a different location on macos, and this location must be injected into the `PATH` before those tools can be used in the same way they are on linux. Adjust the value of `PATH` when a `BuildConfig` runs on a macos host, accordingly.