### PR TITLE
Unmanaged blob

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,19 @@ data_config.server_id = 'bytesalad'
 data_config.root = '${PYTEST_BASETEMP}'
 data_config.match_prefix = '(.*)_result' // .json is appended automatically
 
+data_unmanaged = new DataConfig()
+data_unmanaged.server_id = 'bytesalad'
+data_unmanaged.managed = false
+data_unmanaged.insert("pytest_result",
+    [
+        "files": [
+            [
+                "pattern": "${env.WORKSPACE}/results(.*).xml",
+                "target": "datb-generic"
+            ]
+    ]
+)
+
 
 bc0 = new BuildConfig()
 //bc0.nodetype = 'RHEL-6'
@@ -63,4 +76,9 @@ bc2.test_cmds = ["ls -al ..", // Workspace root.
 bc2.test_configs = []
 
 
-utils.run([bc0, bc1, bc2, jobconfig])
+bc3 = utils.copy(bc0)
+bc3.name = "Fourth build config"
+bc3.test_configs = [data_unmanaged]
+
+
+utils.run([bc0, bc1, bc2, bc3, jobconfig])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,12 +29,11 @@ data_unmanaged = new DataConfig()
 data_unmanaged.server_id = 'bytesalad'
 data_unmanaged.managed = false
 data_unmanaged.insert("pytest_result",
-    [
-        "files": [
-            [
-                "pattern": "${env.WORKSPACE}/results(.*).xml",
-                "target": "datb-generic"
-            ]
+    ["files":
+        [[
+            "pattern": "${env.WORKSPACE}/results(.*).xml",
+            "target": "datb-generic"
+        ]]
     ]
 )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-//@Library('utils@dayfix') _
+@Library('utils@unmanaged-blob') _
 
 // [skip ci] and [ci skip] have no effect here.
 if (utils.scm_checkout(['skip_disable':true])) return

--- a/src/DataConfig.groovy
+++ b/src/DataConfig.groovy
@@ -5,6 +5,7 @@ class DataConfig implements Serializable {
     String root = '.'
     String server_id = ''
     String match_prefix = '(.*)'
+    Boolean managed = true
     Boolean keep_data = false
     int keep_builds = 20
     int keep_days = 10

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -378,33 +378,35 @@ def stageArtifactory(config) {
         for (artifact in config.test_configs) {
             server = Artifactory.server artifact.server_id
 
-            // Construct absolute path to data
-            def path = FilenameUtils.getFullPath(
-                        "${env.WORKSPACE}/${artifact.root}"
-            )
+            if (artifact.managed) {
+                // Construct absolute path to data
+                def path = FilenameUtils.getFullPath(
+                            "${env.WORKSPACE}/${artifact.root}"
+                )
 
-            // Record listing of all files starting at ${path}
-            // (Native Java and Groovy approaches will not
-            // work here)
-            sh(script: "find ${path} -type f",
-               returnStdout: true).trim().tokenize('\n').each {
+                // Record listing of all files starting at ${path}
+                // (Native Java and Groovy approaches will not
+                // work here)
+                sh(script: "find ${path} -type f",
+                   returnStdout: true).trim().tokenize('\n').each {
 
-                // Semi-wildcard matching of JSON input files
-                // ex:
-                //      it = "test_1234_result.json"
-                //      artifact.match_prefix = "(.*)_result"
-                //
-                //      pattern becomes: (.*)_result(.*)\\.json
-                if (it.matches(
-                        artifact.match_prefix + '(.*)\\.json')) {
-                    def basename = FilenameUtils.getBaseName(it)
-                    def data = readFile(it)
+                    // Semi-wildcard matching of JSON input files
+                    // ex:
+                    //      it = "test_1234_result.json"
+                    //      artifact.match_prefix = "(.*)_result"
+                    //
+                    //      pattern becomes: (.*)_result(.*)\\.json
+                    if (it.matches(
+                            artifact.match_prefix + '(.*)\\.json')) {
+                        def basename = FilenameUtils.getBaseName(it)
+                        def data = readFile(it)
 
-                    // Store JSON in a logical map
-                    // i.e. ["basename": [data]]
-                    artifact.insert(basename, data)
-                }
-            } // end find.each
+                        // Store JSON in a logical map
+                        // i.e. ["basename": [data]]
+                        artifact.insert(basename, data)
+                    }
+                } // end find.each
+            }
 
             // Submit each request to the Artifactory server
             artifact.data.each { blob ->


### PR DESCRIPTION
Reminder: Be sure to remove any @Library directive present at the top of Jenkinsfiles before merging into master.

Reminder: Be sure to remove any @Library directive present at the top of Jenkinsfiles before merging into master.

By default `DataConfig.managed` is `true` to preserve existing behavior.

When `DataConfig.managed` is false, the following is true:
- `.match_prefix` is not honored.
- Directory scanning is disabled
- Uploads are controlled entirely by the `DataConfig.insert()` method

Example:
```groovy
def name = "stable-deps"
// ...
dc1 = new DataConfig()
dc1.managed = false
dc1.insert("pytest_results",
    [
        "files": [
            [
                "pattern": "results-${name}.xml",
                "target": "repository_name/path/here/"
            ]
    ]
)
// ...
bc1.name = name
bc1.test_configs = [dc1]