### PR TITLE
Fix environment publication filter

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -183,7 +183,7 @@ def gitCurrentOrigin() {
     return sh(script: "git remote get-url origin", returnStdout: true).trim()
 }
 
-
+// Part of post-build stage. Runs on 'master' node.
 def parseTestReports(buildconfigs) {
     // Unstash all test reports produced by all possible agents.
     // Iterate over all unique files to compose the testing summary.
@@ -312,7 +312,11 @@ def testSummaryNotify(jobconfig, buildconfigs, test_info) {
 def publishCondaEnv(jobconfig, test_info) {
 
     if (jobconfig.enable_env_publication) {
-        def ident = gitCurrentOrigin().tokenize("/")[-2] + "/" + gitCurrentBranch()
+
+        def ident = ''
+        dir("clone") {
+	    ident = gitCurrentOrigin().tokenize("/")[-2] + "/" + gitCurrentBranch()
+        }
         def filter = jobconfig.publish_env_filter.trim()
         def error_message = ""
 


### PR DESCRIPTION
Git information used by the filter comparison logic could not be collected due to not looking in the `clone` subdirectory where the source tree lives on the master node. The observed effect was that build status was set to `FAILED` at the last moment, even though all tests passed, and the environment snapshots were never published.

This PR drops into the `clone` subdir on the master node before collecting the necessary information on which to filter so that the correct info is available for environment snapshot filter use. 

Tested on development branch to verify that build succeeds when the tests pass, and the filter makes the correct comparison between the repo/branch in `JenkinsfileRT` and that information as collected from the clone used to support the build.
