### PR TITLE
Make branch name acquisition for env snapshot filter more robust

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -172,8 +172,6 @@ def installConda(version, install_dir) {
 //
 // @return string
 def gitCurrentBranch() {
-    println(scm.branches[0])
-    println(scm.branches[0].getClass())
     def branch = scm.branches[0].toString().tokenize('/')[-1]
     return branch
 }

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -172,7 +172,10 @@ def installConda(version, install_dir) {
 //
 // @return string
 def gitCurrentBranch() {
-    return sh(script: "git rev-parse --abbrev-ref HEAD", returnStdout: true).trim()
+    println(scm.branches[0])
+    println(scm.branches[0].getClass())
+    def branch = scm.branches[0].toString().tokenize('/')[-1]
+    return branch
 }
 
 
@@ -272,6 +275,7 @@ upload_spec = """
 // as an issue on the the project's Github page.
 //
 // @param jobconfig     JobConfig object
+// Runs on master node.
 def testSummaryNotify(jobconfig, buildconfigs, test_info) {
 
     // If there were any test errors or failures, send the summary to github.


### PR DESCRIPTION
* Use scm object to get branch name
* Convert hudson.plugins.git.BranchSpec to string for manipulation.
* Minor doc update to indicate that `testSummaryNotify` runs on the master node only.
