### PR TITLE
Allow jobConfig.credentials to map vars to custom names.

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -1,0 +1,68 @@
+//@Library('utils@credentials') _
+
+// [skip ci] and [ci skip] have no effect here.
+if (utils.scm_checkout(['skip_disable':true])) return
+
+// Allow modification of the job configuration, affects all relevant build configs.
+// Pass this object in the argument list to the`run()` function below to apply these settings to the job's execution.
+jobconfig = new JobConfig()
+//jobconfig.post_test_summary = true
+//jobconfig.enable_env_publication = true
+//jobconfig.publish_env_on_success_only = false
+
+jobconfig.credentials = [['SECRET_VALUE', 'CUSTOM_CREDENTIAL_VAR'],
+                         'SECRET_VALUE']
+
+
+// Pytest wrapper
+def PYTEST_BASETEMP = "test_outputs"
+def PYTEST = "pytest \
+              -r s \
+              --basetemp=${PYTEST_BASETEMP} \
+              --junit-xml=results.xml"
+
+// Configure artifactory ingest
+data_config = new DataConfig()
+data_config.server_id = 'bytesalad'
+data_config.root = '${PYTEST_BASETEMP}'
+data_config.match_prefix = '(.*)_result' // .json is appended automatically
+
+
+bc0 = new BuildConfig()
+//bc0.nodetype = 'RHEL-6'
+bc0.nodetype = 'linux'
+bc0.name = 'First buildconfig'
+bc0.env_vars = ['VAR_ONE=1',
+               'VAR_TWO=2']
+bc0.conda_ver = '4.6.4'
+bc0.conda_packages = ['python=3.6',
+                     'pytest']
+bc0.build_cmds = ["env",
+                  "./access_env_var.sh",
+                  "ls -al ..", // Workspace root.
+                  "ls -al",    // Project clone dir.
+                  "conda config --show",
+                  "which python",
+                  "conda install ipython"]
+bc0.test_cmds = ["${PYTEST} tests/test_75pass.py"]
+bc0.test_configs = [data_config]
+
+
+bc1 = utils.copy(bc0)
+bc1.name = 'Second'
+bc1.env_vars = ['VAR_THREE=3',
+               'VAR_FOUR=4']
+bc1.test_cmds[1] = "${PYTEST} tests/test_25pass.py"
+
+
+bc2 = utils.copy(bc0)
+bc2.name = 'Third build config'
+bc2.conda_packages = ['python=3.6']
+bc2.build_cmds = ["env",
+                  "which python"]
+bc2.test_cmds = ["ls -al ..", // Workspace root.
+                 "ls -al"]    // Project clone dir.
+bc2.test_configs = []
+
+
+utils.run([bc0, bc1, bc2, jobconfig])

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ jobconfig.post_test_summary = true
 //    To make an environment variable
 //    NOTE: This requires server-side configuration on the Jenkins instance hosting the builds.
 //          Contact a Jenkins administrator to add secrets to the credentials store.
-jobconfig.credentials = ['SECRET_VALUE_AS_ENV_VAR']
+jobconfig.credentials = [
+          'SECRET_VALUE_CREDENTIAL_ID',   // Credential ID as stored in Jenkins, var has same name as ID.
+          ['SECRET_VALUE_CREDENTIAL_ID, CUSTOM_ENV_VAR_NAME']  // Mapping of credental ID to custom env var.
+        ]
 
 
 // Config data to share between builds.
@@ -99,7 +102,7 @@ It has the following properties:
 | `enable_env_publication` | boolean | no | When `true`, and when conda is used during the job (for instance when a `conda_packages` list is provided in a build config), every build configuration (See BuildConfig Class below) that produces an XML test report with no test failures will also publish a list of the environment's packages to an Artifactory repository defined in either a `setup.cfg [tool:pytest]` section _OR_ in a `pytest.ini` file (but not both) using the `results_root` configuration value. i.e. `results_root = <artifactory destination repo>` The environment list file produced is the result of the command `conda list --explicit` from within the active environment and will be named `conda_env_dump_<value of buildconfig.name>.txt`. Note: the Artifactory repository specified must be configured to allow files to be published there. Default value when not specified or no jobconfig object passed to `run()`: `false` |
 | `publish_env_filter` | string | yes | Only publish the environment when the current git origin and branch matches within the pipeline job. The expected format is `user/branch` (e.g. `spacetelescope/master`). Wildcard operators are not supported. To override this behavior set the environment variable `JSCIU_ENV_PUBLISH_FORCE=1`. |
 | `publish_env_on_success_only` | boolean | no | When `enable_env_publication` is set to true, a `false` value for this option will publish a package list of any conda environments that are used in each build configuration, even if the test results contain failures. Default value when not specified or no jobconfig object passed to `run()`: `true` |
-| `credentials` | list of strings | no | If string-type credentials have been added to Jenkins's internal credentials store in a scope available to the job in question, adding the credential ID value(s) here in a comma separated list of strings will cause the value of each credential item to be injected into the runtime environment of each build configuration hosted by the job as an environment variable with the same name as the credential ID. |
+| `credentials` | list of strings or lists | no | If string-type credentials have been added to Jenkins's internal credentials store in a scope available to the job in question, adding the credential ID value(s) here in a comma separated list of strings will cause the value of each credential item to be injected into the runtime environment of each build configuration hosted by the job as an environment variable with the same name as the credential ID. If instead a custom environment variable name is desired onto which the value of a stored credential secret is to be mapped, it may be supplied as the second element of a list. I.e. `['SECRET_VALUE_CREDENTIAL_ID, CUSTOM_ENV_VAR_NAME']` as shown in the example Jenkinsfile above. |
 
 #### Test Summary Issue Posts
 If test summaries are requested using the `post_test_summary` property of the JobConfig class as described above, each Jenkins job that produces one or more test errors or failures will result in a single new Github issue being posted to the project's repository.

--- a/access_env_var.sh
+++ b/access_env_var.sh
@@ -2,3 +2,6 @@
 
 echo "This is the value of SECRET_VALUE"
 echo "${SECRET_VALUE}"
+
+echo "This is the value of CUSTOM_CREDENTIAL_VAR"
+echo "${CUSTOM_CREDENTIAL_VAR}"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -882,12 +882,21 @@ def run(configs, concurrent = true) {
         // Make any requested credentials available to all build configs
         // in this job via environment variables.
         if (jobconfig.credentials != null) {
-            jobconfig.credentials.each { cred_id ->
-              withCredentials([string(credentialsId: cred_id, variable: 'cred_id_val')]) {
-                  config.env_vars.add("${cred_id}=${cred_id_val}".toString())
-                }
-            }
+            jobconfig.credentials.each { cred ->
+              if (cred.getClass() == java.lang.String) {
+                  withCredentials([string(credentialsId: cred, variable: 'cred_val')]) {
+                      config.env_vars.add("${cred}=${cred_val}".toString())
+                    }
+              }
+              if (cred.getClass() == java.util.ArrayList) {
+                  withCredentials([string(credentialsId: cred[0], variable: 'cred_val')]) {
+                      config.env_vars.add("${cred[1]}=${cred_val}".toString())
+                    }
+              }
+
+            } //end .each
         }
+
 
         def BuildConfig myconfig = new BuildConfig() // MUST be inside eachWith loop.
         myconfig = SerializationUtils.clone(config)


### PR DESCRIPTION
And update readme to reflect credentials env var mapping capability.


