### PR TITLE
Use latest miniconda installer to prevent install issues

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -103,13 +103,9 @@ def condaPresent() {
 //                   otherwise
 def installConda(version, install_dir) {
 
-    installer_ver = '4.5.12'
-    default_conda_version = '4.5.12'
+    installer_ver = 'latest'
     default_dir = 'miniconda'
 
-    if (version == null) {
-        version = default_conda_version
-    }
     if (install_dir == null) {
         install_dir = default_dir
     }
@@ -159,10 +155,12 @@ def installConda(version, install_dir) {
     sh "bash ./${conda_installer} -b -p ${install_dir}"
 
     // Override conda version if specified and different from default.
-    def curr_ver = sh(script:"${conda_exe} --version", returnStdout: true)
-    curr_ver = curr_ver.tokenize()[1].trim()
-    if (curr_ver != version) {
-        sh "${conda_exe} install -q conda=${version}"
+    if (version != null) {
+        def curr_ver = sh(script:"${conda_exe} --version", returnStdout: true)
+        curr_ver = curr_ver.tokenize()[1].trim()
+        if (curr_ver != version) {
+            sh "${conda_exe} install -q conda=${version}"
+        }
     }
 
     return true
@@ -565,7 +563,7 @@ def buildAndTest(config) {
             // - Generate pip freeze list.
             // - Replace all VCS dependencies in pip freeze list with the full git+http dependency
             //   specs collected earlier.
-            // 
+            //
             //  TODO:
             // - Generate conda export file.
             // - Replace all VCS dependencies in export file with the full git+http dependency
@@ -729,7 +727,7 @@ def expandEnvVars(config) {
     // Expand environment variable specifications by using the shell
     // to dereference any var references and then render the entire
     // value as a canonical path.
-    
+
     // Override the HOME dir to be the job workspace.
     config.env_vars.add("HOME=${env.WORKSPACE}")
 


### PR DESCRIPTION
The JWST regression test jobs are failing because miniconda 4.5.12 is having trouble talking to the package repo:

https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2Feslavich-dev/detail/eslavich-dev/63/pipeline/

The latest miniconda does not have this problem.