### PR TITLE
Update Jenkins Shared CI to accept builds without setup.cfg

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -404,15 +404,15 @@ def publishCondaEnv(jobconfig, test_info) {
                     throw new Exception("Error: Value for 'pub_repo' not found in existing file 'pyproject.toml'")
                 }
             }
-            else if (env.TEST_BIGDATA) {
-                // Populate pub_repo from environment variable
-                println("PROP->${env.TEST_BIGDATA.replaceAll("'","")}")
-                pub_repo = env.TEST_BIGDATA.replaceAll("'","")
-                println("Variable 'pub_repo' populated by information from environment variable 'TEST_BIGDATA'")
+            else if (env.TEST_RESULTS_ROOT) {
+                // Populate pub_repo from environment variable 'TEST_RESULTS_ROOT'
+                println("PROP->${env.TEST_RESULTS_ROOT.replaceAll("'","")}")
+                pub_repo = env.TEST_RESULTS_ROOT.replaceAll("'","")
+                println("Variable 'pub_repo' populated by information from environment variable 'TEST_RESULTS_ROOT")
             }
             else {
                 // throw exception if value for 'pub_repo' could not be found.
-                throw new Exception("Error: Value for 'pub_repo' not found in files 'setup.cfg' of 'pyproject.toml' or in environment variable 'TEST_BIGDATA'")
+                throw new Exception("Error: Value for 'pub_repo' not found in files 'setup.cfg' of 'pyproject.toml' or in environment variable 'TEST_RESULTS_ROOT'")
             }
             if (jobconfig.publish_env_on_success_only) {
                 if (!test_info.problems) {

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -377,11 +377,27 @@ def publishCondaEnv(jobconfig, test_info) {
 
         // Extract repo from standardized location
         dir('clone') {
-            def testconf = readFile("setup.cfg")
-            def Properties prop = new Properties()
-            prop.load(new StringReader(testconf))
-            println("PROP->${prop.getProperty('results_root')}")
-            pub_repo = prop.getProperty('results_root')
+            if (fileExists('setup.cfg')) {
+                // Get pub_repo from value stored in setup.cfg file
+                def testconf = readFile("setup.cfg")
+                def Properties prop = new Properties()
+                prop.load(new StringReader(testconf))
+                println("PROP->${prop.getProperty('results_root')}")
+                pub_repo = prop.getProperty('results_root')
+            }
+            else if (fileExists('pyproject.toml')) {
+                // Get pub_repo from value stored in pyproject.toml file
+                // TODO: figure out how to pull 'results_root' value from pyproject.toml file
+                println("TODO: figure out how to pull 'results_root' value from pyproject.toml file")
+            }
+            else if (env.TEST_BIGDATA) {
+                // Get pub_repo from environment variable
+                def pub_repo = env.TEST_BIGDATA)
+            }
+            else {
+                // throw error if value for 'pub_repo' cannot be found.
+                // TODO: Figure out how to throw error and exit here.
+                println("TODO: Figure out how to throw error and exit here.")
 
             if (jobconfig.publish_env_on_success_only) {
                 if (!test_info.problems) {
@@ -392,6 +408,7 @@ def publishCondaEnv(jobconfig, test_info) {
                 pushToArtifactory("conda_python_*", pub_repo)
                 pushToArtifactory("reqs_*", pub_repo)
             }
+
         } // end dir(...
     }
 }

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -404,10 +404,10 @@ def publishCondaEnv(jobconfig, test_info) {
                     throw new Exception("Error: Value for 'pub_repo' not found in existing file 'pyproject.toml'")
                 }
             }
-            else if (System.env['TEST_BIGDATA']) {
+            else if (env.TEST_BIGDATA) {
                 // Populate pub_repo from environment variable
-                println("PROP->${System.env['TEST_BIGDATA'].replaceAll("'","")}")
-                pub_repo = System.env['TEST_BIGDATA'].replaceAll("'","")
+                println("PROP->${env.TEST_BIGDATA.replaceAll("'","")}")
+                pub_repo = env.TEST_BIGDATA.replaceAll("'","")
                 println("Variable 'pub_repo' populated by information from environment variable 'TEST_BIGDATA'")
             }
             else {

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -387,13 +387,21 @@ def publishCondaEnv(jobconfig, test_info) {
                 println("Variable 'pub_repo' populated by information from file 'setup.cfg'")
             }
             else if (new File('pyproject.toml').exists()) {
-                // Populate pub_repo from value stored in pyproject.toml file
+                // Get pub_repo from value stored in pyproject.toml file
                 File file = new File('pyproject.toml')
-                String fileContent = file.text
-                def toml = new TomlSlurper().parseText(fileContent)
-                println("PROP->${toml.tool.pytest.ini_options.results_root}")
-                def pub_repo = toml.tool.pytest.ini_options.results_root
-                println("Variable 'pub_repo' populated by information from file 'pyproject.toml'")
+                def lines = file.readLines()
+                def pub_repo = ""
+                file.eachLine { String line ->
+                    if (line.startsWith("results_root")) {
+                        println("PROP->${line.split(" = ")[1]}")
+                        pub_repo = line.split(" = ")[1]
+                        println("Variable 'pub_repo' populated by information from file 'pyproject.toml'")
+                    }
+                }
+                if (pub_repo == "") {
+                    // throw error if value for 'pub_repo' cannot be found.
+                    throw new Exception("Error: Value for 'pub_repo' not found in existing file 'pyproject.toml'")
+                }
             }
             else if (System.env['TEST_BIGDATA']) {
                 // Populate pub_repo from environment variable

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -377,7 +377,7 @@ def publishCondaEnv(jobconfig, test_info) {
 
         // Extract repo from standardized location
         dir('clone') {
-            if (new File('setup.cfg').exists()) {
+            if (fileExists('setup.cfg')) {
                 // Populate pub_repo from value stored in setup.cfg file
                 def testconf = readFile("setup.cfg")
                 def Properties prop = new Properties()
@@ -386,7 +386,7 @@ def publishCondaEnv(jobconfig, test_info) {
                 def pub_repo = prop.getProperty('results_root')
                 println("Variable 'pub_repo' populated by information from file 'setup.cfg'")
             }
-            else if (new File('pyproject.toml').exists()) {
+            else if (fileExists('pyproject.toml')) {
                 // Get pub_repo from value stored in pyproject.toml file
                 File file = new File('pyproject.toml')
                 def lines = file.readLines()
@@ -397,7 +397,6 @@ def publishCondaEnv(jobconfig, test_info) {
                         pub_repo = line.split(" = ")[1]
                         println("Variable 'pub_repo' populated by information from file 'pyproject.toml'")
                     }
-                }
                 if (pub_repo == "") {
                     // throw error if value for 'pub_repo' cannot be found.
                     throw new Exception("Error: Value for 'pub_repo' not found in existing file 'pyproject.toml'")

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -392,7 +392,7 @@ def publishCondaEnv(jobconfig, test_info) {
             }
             else if (env.TEST_BIGDATA) {
                 // Get pub_repo from environment variable
-                def pub_repo = env.TEST_BIGDATA)
+                def pub_repo = env.TEST_BIGDATA
             }
             else {
                 // throw error if value for 'pub_repo' cannot be found.


### PR DESCRIPTION
Relevant JIRA ticket: [SPB-1206](https://jira.stsci.edu/browse/SPB-1206)

**SUMMARY OF CHANGES**
- Added logic to **utils.groovy** to allow the _pub_repo_ variable to be populated by information stored in either the **setup.cfg** file, the **pyproject.toml** file or the _TEST_RESULTS_ROOT_ environment variable
- logic tree also contains code to throw an exception if relevant information cannot be found in any of the three above locations.
- Previously, the _pub_repo_ variable was only populated by information stored the **setup.cfg** file.