### PR TITLE
updating miniconda version to support python 3.9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,8 @@ bc0.nodetype = 'linux'
 bc0.name = 'First buildconfig'
 bc0.env_vars = ['VAR_ONE=1',
                'VAR_TWO=2']
-bc0.conda_ver = '4.6.4'
-bc0.conda_packages = ['python=3.6',
+bc0.conda_ver = '23.1.0-1'
+bc0.conda_packages = ['python=3.9',
                      'pytest']
 bc0.build_cmds = ["env",
                   "ls -al ..", // Workspace root.
@@ -55,7 +55,7 @@ bc1.test_cmds[1] = "${PYTEST} tests/test_25pass.py"
 
 bc2 = utils.copy(bc0)
 bc2.name = 'Third build config'
-bc2.conda_packages = ['python=3.6']
+bc2.conda_packages = ['python=3.9']
 bc2.build_cmds = ["env",
                   "which python"]
 bc2.test_cmds = ["ls -al ..", // Workspace root.

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -35,7 +35,7 @@ bc0.name = 'First buildconfig'
 bc0.env_vars = ['VAR_ONE=1',
                'VAR_TWO=2']
 bc0.conda_ver = '4.6.4'
-bc0.conda_packages = ['python=3.6',
+bc0.conda_packages = ['python=3.9',
                      'pytest']
 bc0.build_cmds = ["env",
                   "./access_env_var.sh",
@@ -57,7 +57,7 @@ bc1.test_cmds[1] = "${PYTEST} tests/test_25pass.py"
 
 bc2 = utils.copy(bc0)
 bc2.name = 'Third build config'
-bc2.conda_packages = ['python=3.6']
+bc2.conda_packages = ['python=3.9']
 bc2.build_cmds = ["env",
                   "which python"]
 bc2.test_cmds = ["ls -al ..", // Workspace root.

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -142,8 +142,8 @@ def condaPresent() {
 //                   otherwise
 def installConda(version, install_dir) {
 
-    installer_ver = '4.5.12'
-    default_conda_version = '4.5.12'
+    installer_ver = '23.1.0-1'
+    default_conda_version = '23.1.0-1'
     default_dir = 'miniconda'
 
     if (version == null) {
@@ -725,7 +725,7 @@ def buildAndTest(config) {
 // If conda packages were specified, create an environment containing
 // them and then 'activate' it by setting key environment variables that
 // influence conda's behavior. . If a specific python version is
-// desired, it must be specified as a package, i.e. 'python=3.6'
+// desired, it must be specified as a package, i.e. 'python=3.9'
 // in the list config.conda_packages.
 //
 // @param config  BuildConfig object


### PR DESCRIPTION
Reminder: Be sure to remove any @Library directive present at the top of Jenkinsfiles before merging into master.